### PR TITLE
Fixed ZuckLess link on manifesto

### DIFF
--- a/content/manifesto.md
+++ b/content/manifesto.md
@@ -56,7 +56,7 @@ We do this by supporting [researchers]() and providing services that social netw
 
 #### Data Reuse
 
-Our first experiment on data reuse: [ZuckLess News](https://eu19.tracking.exposed/language/), [YouTube data compare](https://youtube.tracking.exposed/compare), and [YouTube related search](https://youtube.tracking.exposed/realted)
+Our first experiment on data reuse: [ZuckLess News](https://facebook.tracking.exposed/zuckless-news/), [YouTube data compare](https://youtube.tracking.exposed/compare), and [YouTube related search](https://youtube.tracking.exposed/realted)
 
 #### Focus campaigns
 


### PR DESCRIPTION
Previous link was pointing to EU election page